### PR TITLE
fix: require 3.8+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ["py39"]
+target-version = ["py38"]
 preview = true
 
 [tool.isort]


### PR DESCRIPTION
Original code requires even 3.7+, but we need 3.8 at worst right now.

Please trigger a release right away.